### PR TITLE
Fix CI: render manifests in cluster devShell, drop unused id-token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -38,4 +37,4 @@ jobs:
         run: nix build .#nixosConfigurations.nas.config.system.build.toplevel
       # pi is aarch64-linux, skipped in CI (would require QEMU/cross-compilation)
       - name: Render cluster manifests
-        run: cd cluster && nix develop .. -c just render-lab
+        run: cd cluster && nix develop . -c just render-lab


### PR DESCRIPTION
The "Render cluster manifests" step ran `nix develop ..`, entering the
root flake's devShell, which only provides pre-commit/formatting tools
(deadnix, alejandra, trufflehog, nil) — not `just`, `tanka`, or
`jsonnet`. That made `just render-lab` fail with exit 127 (command not
found) on every PR, since the step runs unconditionally. Point it at
`cluster/`'s own flake (`nix develop .`), which provides those tools.

Also drop `id-token: write`: it triggers a FlakeHub OIDC login attempt
in determinate-nix-action that fails (repo isn't enrolled) and emits a
spurious "FlakeHub Login failure" annotation. FlakeHub is unused here
(magic-nix-cache runs with use-flakehub: false), so the permission is
unnecessary.

https://claude.ai/code/session_01FdMuaBFWaGN18198UQY9fv