### PR TITLE
nixpkgs 26.05 compatibility: initrd ssh shell + nodejs bump (unblocks PR #16)

### DIFF
--- a/machines/eachtrai/default.nix
+++ b/machines/eachtrai/default.nix
@@ -246,7 +246,7 @@
       chromium
       pgformatter
       wakeonlan
-      nodejs_20
+      nodejs_24
       ripgrep
       claude-code
     ];

--- a/machines/saoiste/default.nix
+++ b/machines/saoiste/default.nix
@@ -113,9 +113,8 @@
   boot.initrd.network.ssh = {
     enable = true;
     port = 22;
-    shell = "/bin/cryptsetup-askpass";
     authorizedKeys = [
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjXUsGrBVN0jkm39AqfoEIG4PLxmefofNJPUtJeRnIoLZGMaS8Lw/tReVKx64+ttFWLAdkfi+djJHATxwMhhD8BwfJoP5RCz+3P97p1lQh6CjM0XrzTE9Ol6X1/D/mgS4oVa5YaVw3VszxN6Hm2BimKobvfHuIK5w/f0BoBIWxdvs0YyxCJvPsyIfmEvd8CPug9A8bo1/ni77AMpAWuw2RbEBJMk3sxHqUsHlCX/aPTjEqPusictHuy3xoHc4DSxgE/IZkV/d4wOzOUHaM+W8oKvBy8X00rMMprQ1e81WUySkh4UwgplNoD/hHGuVD0EN94ISkjwOfPGW0ACP7bVkZ"
+      "command=\"systemctl default\" ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjXUsGrBVN0jkm39AqfoEIG4PLxmefofNJPUtJeRnIoLZGMaS8Lw/tReVKx64+ttFWLAdkfi+djJHATxwMhhD8BwfJoP5RCz+3P97p1lQh6CjM0XrzTE9Ol6X1/D/mgS4oVa5YaVw3VszxN6Hm2BimKobvfHuIK5w/f0BoBIWxdvs0YyxCJvPsyIfmEvd8CPug9A8bo1/ni77AMpAWuw2RbEBJMk3sxHqUsHlCX/aPTjEqPusictHuy3xoHc4DSxgE/IZkV/d4wOzOUHaM+W8oKvBy8X00rMMprQ1e81WUySkh4UwgplNoD/hHGuVD0EN94ISkjwOfPGW0ACP7bVkZ"
     ];
     hostKeys = ["/etc/secrets/initrd/ssh_host_rsa_key"];
   };

--- a/role/packages.nix
+++ b/role/packages.nix
@@ -159,7 +159,7 @@
 
     waypaper
     waybar
-    nodejs_20
+    nodejs_24
     perf
     nil
     inputs.agenix.packages.x86_64-linux.agenix


### PR DESCRIPTION
Makes all NixOS configs build under nixpkgs **26.05** so the `flake.lock` bump in #16 can go green. Two independent 26.05 blockers, verified by evaluating `saoiste`, `eachtrai`, `nuc`, and `nas` `toplevel` against #16's 26.05 `flake.lock` (no `NIXPKGS_ALLOW_INSECURE`):

### 1. initrd ssh unlock — `cryptsetup-askpass` assertion (saoiste)
26.05 defaults to systemd stage-1 initrd, which rejects `boot.initrd.network.ssh.shell = "/bin/cryptsetup-askpass"`:
```
cryptsetup-askpass is not available in systemd stage 1.
Please remove it from: boot.initrd.systemd.users.root.shell
```
Per the release notes: drop the custom shell, restrict the initrd SSH key with `command="systemctl default"` (resumes boot / LUKS prompt after remote login).

### 2. `nodejs_20` EOL/insecure (saoiste + eachtrai)
26.05 marks `nodejs-20.20.2` insecure (end of life), so it refuses to evaluate. Bumped `nodejs_20` → `nodejs_24` in `role/packages.nix` and `machines/eachtrai/default.nix`.

`nuc` and `nas` were already clean. This PR does **not** touch `flake.lock` — that's #16; merge this first, then rebase #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)